### PR TITLE
Basic main menu view from homepage

### DIFF
--- a/Balance.xcodeproj/project.pbxproj
+++ b/Balance.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		2F5E32BD297E05EA003432F8 /* BalanceAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5E32BC297E05EA003432F8 /* BalanceAppDelegate.swift */; };
 		2FC9759F2978E39600BA99FE /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2FC9759E2978E39600BA99FE /* Localizable.strings */; };
 		2FC975A82978F11A00BA99FE /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC975A72978F11A00BA99FE /* Home.swift */; };
+		5EDB5666299E14DB0023F9BE /* Diary in Frameworks */ = {isa = PBXBuildFile; productRef = 5EDB5665299E14DB0023F9BE /* Diary */; };
+		5EDB5668299E14DB0023F9BE /* Meditation in Frameworks */ = {isa = PBXBuildFile; productRef = 5EDB5667299E14DB0023F9BE /* Meditation */; };
+		5EDB566A299E200F0023F9BE /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDB5669299E200F0023F9BE /* MenuView.swift */; };
 		653A2551283387FE005D4D48 /* Balance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A2550283387FE005D4D48 /* Balance.swift */; };
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* BalanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* BalanceTests.swift */; };
@@ -64,6 +67,7 @@
 		2FC94CD4298B0A1D009C8209 /* Balance.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Balance.xctestplan; sourceTree = "<group>"; };
 		2FC9759E2978E39600BA99FE /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		2FC975A72978F11A00BA99FE /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
+		5EDB5669299E200F0023F9BE /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		653A254D283387FE005D4D48 /* Balance.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Balance.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A2550283387FE005D4D48 /* Balance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Balance.swift; sourceTree = "<group>"; };
 		653A255428338800005D4D48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -84,9 +88,11 @@
 				2F49B77E2980407C00BCB272 /* Scheduler in Frameworks */,
 				2F59B93F298C628800C5107F /* BalanceMockDataStorageProvider in Frameworks */,
 				2F49B77A2980407C00BCB272 /* HealthKitDataSource in Frameworks */,
+				5EDB5668299E14DB0023F9BE /* Meditation in Frameworks */,
 				2F59B945298C628800C5107F /* BalanceSharedContext in Frameworks */,
 				2F49B784298041F300BCB272 /* Contact in Frameworks */,
 				2F49B7782980407C00BCB272 /* FHIR in Frameworks */,
+				5EDB5666299E14DB0023F9BE /* Diary in Frameworks */,
 				2F49B7802980418400BCB272 /* Onboarding in Frameworks */,
 				2F59B943298C628800C5107F /* BalanceSchedule in Frameworks */,
 				2F49B7762980407C00BCB272 /* CardinalKit in Frameworks */,
@@ -162,6 +168,7 @@
 				2F5E32BC297E05EA003432F8 /* BalanceAppDelegate.swift */,
 				2F4E23822989D51F0013F3D9 /* BalanceAppTestingSetup.swift */,
 				2FC975A72978F11A00BA99FE /* Home.swift */,
+				5EDB5669299E200F0023F9BE /* MenuView.swift */,
 				2FC9759D2978E30800BA99FE /* Supporting Files */,
 			);
 			path = Balance;
@@ -224,6 +231,8 @@
 				2F59B940298C628800C5107F /* BalanceOnboardingFlow */,
 				2F59B942298C628800C5107F /* BalanceSchedule */,
 				2F59B944298C628800C5107F /* BalanceSharedContext */,
+				5EDB5665299E14DB0023F9BE /* Diary */,
+				5EDB5667299E14DB0023F9BE /* Meditation */,
 			);
 			productName = TemplateApplication;
 			productReference = 653A254D283387FE005D4D48 /* Balance.app */;
@@ -350,6 +359,7 @@
 				2F4E23832989D51F0013F3D9 /* BalanceAppTestingSetup.swift in Sources */,
 				2F5E32BD297E05EA003432F8 /* BalanceAppDelegate.swift in Sources */,
 				653A2551283387FE005D4D48 /* Balance.swift in Sources */,
+				5EDB566A299E200F0023F9BE /* MenuView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -800,6 +810,14 @@
 		2F59B944298C628800C5107F /* BalanceSharedContext */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BalanceSharedContext;
+		};
+		5EDB5665299E14DB0023F9BE /* Diary */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Diary;
+		};
+		5EDB5667299E14DB0023F9BE /* Meditation */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Meditation;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Balance/Home.swift
+++ b/Balance/Home.swift
@@ -15,17 +15,23 @@ import SwiftUI
 
 struct HomeView: View {
     enum Tabs: String {
+        case menu
         case schedule
         case contact
         case mockUpload
     }
     
-    
     @AppStorage(StorageKeys.homeTabSelection) var selectedTab = Tabs.schedule
     
+    @State var navigationPath = NavigationPath()
     
     var body: some View {
         TabView(selection: $selectedTab) {
+            MenuView(navigationPath: $navigationPath)
+                .tag(Tabs.menu)
+                .tabItem {
+                    Label("MENU_TAB_TITLE", systemImage: "filemenu.and.selection")
+                }
             ScheduleView()
                 .tag(Tabs.schedule)
                 .tabItem {
@@ -42,6 +48,7 @@ struct HomeView: View {
                     Label("MOCK_UPLOAD_TAB_TITLE", systemImage: "server.rack")
                 }
         }
+        
     }
 }
 

--- a/Balance/MenuView.swift
+++ b/Balance/MenuView.swift
@@ -1,0 +1,61 @@
+//
+//  Menu.swift
+//  Balance
+//
+//  Created by Alexis Lowber on 2/16/23.
+//
+
+import Diary
+import Meditation
+import SwiftUI
+
+
+enum Feature: String, CaseIterable {
+    case meditation = "Meditation"
+    case diary = "Diary"
+    
+    func featureView(with navigationPath: Binding<NavigationPath>) -> some View {
+        @ViewBuilder
+        var featureView: some View {
+            switch self {
+            case .meditation:
+                MeditationView(navigationPath: navigationPath)
+            case .diary:
+                DiaryView(navigationPath: navigationPath)
+            }
+        }
+        return featureView
+    }
+}
+
+
+struct MenuView: View {
+    
+    @Binding var navigationPath: NavigationPath
+    
+    var body: some View {
+        NavigationStack {
+            List(Feature.allCases, id: \.self) { feature in
+                Section(feature.rawValue) {
+                    NavigationLink(feature.rawValue, value: feature)
+                }
+            }
+            .navigationDestination(for: Feature.self) { feature in
+                feature.featureView(with: $navigationPath)
+            }
+            .navigationTitle("Features")
+        }
+    }
+    
+    public init(navigationPath: Binding<NavigationPath>) {
+        self._navigationPath = navigationPath
+    }
+}
+
+struct MenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            MenuView(navigationPath: .constant(NavigationPath()))
+        }
+    }
+}

--- a/Balance/Supporting Files/Assets.xcassets/AppIcon.appiconset/1024.png
+++ b/Balance/Supporting Files/Assets.xcassets/AppIcon.appiconset/1024.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ceaf68583bb602b55d7fb2018aaa19419755fb47fd958a39233bee70b649d34
-size 122340

--- a/Balance/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Balance/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,7 +1,6 @@
 {
   "images" : [
     {
-      "filename" : "1024.png",
       "idiom" : "universal",
       "platform" : "ios",
       "size" : "1024x1024"

--- a/Balance/Supporting Files/Localizable.strings
+++ b/Balance/Supporting Files/Localizable.strings
@@ -7,6 +7,10 @@
 //
 
 
+// MARK: - Main Menu
+"MENU_TAB_TITLE" = "Main Menu";
+
+
 // MARK: - Contacts
 "CONTACTS_TAB_TITLE" = "Contacts";
 

--- a/BalanceModules/Package.swift
+++ b/BalanceModules/Package.swift
@@ -22,7 +22,9 @@ let package = Package(
         .library(name: "BalanceMockDataStorageProvider", targets: ["BalanceMockDataStorageProvider"]),
         .library(name: "BalanceOnboardingFlow", targets: ["BalanceOnboardingFlow"]),
         .library(name: "BalanceSchedule", targets: ["BalanceSchedule"]),
-        .library(name: "BalanceSharedContext", targets: ["BalanceSharedContext"])
+        .library(name: "BalanceSharedContext", targets: ["BalanceSharedContext"]),
+        .library(name: "Diary", targets: ["Diary"]),
+        .library(name: "Meditation", targets: ["Meditation"]),
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordBDHG/CardinalKit.git", .upToNextMinor(from: "0.2.1"))
@@ -72,6 +74,14 @@ let package = Package(
         ),
         .target(
             name: "BalanceSharedContext",
+            dependencies: []
+        ),
+        .target(
+            name: "Diary",
+            dependencies: []
+        ),
+        .target(
+            name: "Meditation",
             dependencies: []
         )
     ]

--- a/BalanceModules/Sources/Diary/DiaryView.swift
+++ b/BalanceModules/Sources/Diary/DiaryView.swift
@@ -1,0 +1,29 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Alexis Lowber on 2/14/23.
+//
+
+import SwiftUI
+
+public struct DiaryView: View {
+    @Binding var navigationPath: NavigationPath
+    
+    public var body: some View {
+        Text("Welcome to the Diary View")
+    }
+    
+    public init(navigationPath: Binding<NavigationPath>) {
+        self._navigationPath = navigationPath
+    }
+}
+
+struct DiaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            DiaryView(navigationPath: .constant(NavigationPath()))
+        }
+    }
+    
+}

--- a/BalanceModules/Sources/Meditation/MeditationView.swift
+++ b/BalanceModules/Sources/Meditation/MeditationView.swift
@@ -1,0 +1,33 @@
+//
+//  SwiftUIView.swift
+//  
+//
+//  Created by Alexis Lowber on 2/14/23.
+//
+
+/*
+ might want to check out NavigationSplit view if you want a two-column presentation w meditation options and views. See here: https://developer.apple.com/videos/play/wwdc2022/10054/
+ */
+
+
+import SwiftUI
+
+public struct MeditationView: View {
+    @Binding var navigationPath: NavigationPath
+    
+    public var body: some View {
+        Text("Welcome to the Meditation View")
+    }
+    
+    public init(navigationPath: Binding<NavigationPath>) {
+        self._navigationPath = navigationPath
+    }
+}
+
+struct MeditationView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            MeditationView(navigationPath: .constant(NavigationPath()))
+        }
+    }
+}


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Basic main menu view from homepage

## :recycle: Current situation & Problem
currently, there is no main menu that we can use as a root view from which users navigate to different parts of the app.

## :bulb: Proposed solution
This PR adds a Main Menu view that has a list wiht navigation links to the diary and meditation features.

## :heavy_plus_sign: Additional Information
TODO: add testing for navigation + incorporate better UI into main menu (this is just the bare bones)

### Testing
No, but these will need to be added

### Reviewer Nudging
Home page

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

