### PR TITLE
Use Self-Hosted Runners

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -18,11 +18,10 @@ jobs:
   buildandtest:
     name: Build and Test
     uses: ./.github/workflows/build-and-test.yml
-    secrets: inherit
   iosapptestflightdeployment:
     name: iOS App TestFlight Deployment
     needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     secrets: inherit
     with:
       artifactname: Balance.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,18 +16,17 @@ on:
 jobs:
   reuse_action:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
-    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v1
+    uses: StanfordBDHG/.github/.github/workflows/swiftlint.yml@v2
   buildandtest:
     name: Build and Test
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     with:
       artifactname: Balance.xcresult
-      runsonlabels: '["macos-latest"]'
-      setupfirebaseemulator: true
-      customcommand: "firebase emulators:exec 'fastlane test'"
+      runsonlabels: '["macOS", "self-hosted"]'
+      fastlanelane: test
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,8 @@ jobs:
     with:
       artifactname: Balance.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
-      fastlanelane: test
+      setupfirebaseemulator: true
+      customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest

--- a/BalanceUITests/OnboardingTests.swift
+++ b/BalanceUITests/OnboardingTests.swift
@@ -140,7 +140,7 @@ extension XCUIApplication {
     }
     
     private func navigateOnboardingFlowHealthKitAccess(assertThatHealthKitConsentIsShown: Bool = true) throws {
-        XCTAssertTrue(staticTexts["HealthKit Access"].waitForExistence(timeout: 2))
+        XCTAssertTrue(staticTexts["HealthKit Access"].waitForExistence(timeout: 5))
         
         XCTAssertTrue(buttons["Grant Access"].waitForExistence(timeout: 2))
         buttons["Grant Access"].tap()


### PR DESCRIPTION
# Use Self-Hosted Runners

## :bulb: Proposed solution
- Switches to a reusable workflow and uses the self-hosted runners.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
