### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     uses: CS342/.github/.github/workflows/xcodebuild-or-fastlane.yml@v1
     with:
       artifactname: Balance.xcresult
-      runsonlabels: '["macOS", "self-hosted"]'
+      runsonlabels: '["macos-latest"]'
       setupfirebaseemulator: true
       customcommand: "firebase emulators:exec 'fastlane test'"
   uploadcoveragereport:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -378,6 +378,7 @@ deployment_target: # Availability checks or attributes shouldn’t be using olde
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - .build
   - .swiftpm
+  - .derivedData
 
 closure_body_length: # Closure bodies should not span too many lines.
   - 35 # warning - default: 20


### PR DESCRIPTION
# Update GitHub Actions

## :recycle: Current situation & Problem
- We will retire the self-hosted GitHub Runners for the CS342 Organization for now.

## :bulb: Proposed solution
- Moves the GitHub Action to use the GitHub-hosted runners.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

