### PR TITLE
Adds missing games to the rewarding system (BAL-191)

### DIFF
--- a/Balance/ActivityLogging/ActivityStorageManager.swift
+++ b/Balance/ActivityLogging/ActivityStorageManager.swift
@@ -118,6 +118,11 @@ class ActivityLogEntry: ObservableObject, Codable {
             actionDescription.contains("Closed Video Selected") ||
             actionDescription.contains("Closed Sudoku Game") ||
             actionDescription.contains("Closed Crossover Game") ||
+            actionDescription.contains("Closed Tetris Game") ||
+            actionDescription.contains("Closed Simon Says Game") ||
+            actionDescription.contains("Closed Bouncing Ball Game") ||
+            actionDescription.contains("Closed 2048 Game") ||
+            actionDescription.contains("Closed Solitaire Game") ||
             actionDescription.contains("Closed Guess the Emotion") ||
             actionDescription.contains("Closed How is your mood") ||
             actionDescription.contains("Closed New Draw") ||


### PR DESCRIPTION
# Adds missing games to the rewarding system

## :recycle: Current situation & Problem
After we removed and added some other games, we missed registering them in the rewarding system. 
This means participants don't get rewarded for playing the following games:
* Solitaire
* 2048
* Bouncing
* Simon Says
* Tetris

Refer to #191 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
