### PR TITLE
Fix SwiftLint failures for latest version (#209)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,11 @@ jobs:
     with:
       artifactname: Balance.xcresult
       setupfirebaseemulator: true
-      customcommand: "firebase emulators:exec 'fastlane test'"
+      customcommand: |
+        export JAVA_HOME="$JAVA_HOME_21_X64"
+        export PATH="$JAVA_HOME/bin:$PATH"
+        java -version
+        firebase emulators:exec 'fastlane test'
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: buildandtest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
       artifactname: Balance.xcresult
       setupfirebaseemulator: true
       customcommand: |
-        export JAVA_HOME="$JAVA_HOME_21_X64"
+        export JAVA_HOME="$JAVA_HOME_21_arm64"
         export PATH="$JAVA_HOME/bin:$PATH"
         java -version
         firebase emulators:exec 'fastlane test'

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -139,8 +139,6 @@ only_rules:
   - implicitly_unwrapped_optional
   # Identifiers should use inclusive language that avoids discrimination against groups of people based on race, gender, or socioeconomic status
   - inclusive_language
-  # If defer is at the end of its parent scope, it will be executed right where it is anyway.
-  - inert_defer
   # Prefer using Set.isDisjoint(with:) over Set.intersection(_:).isEmpty.
   - is_disjoint
   # Discouraged explicit usage of the default separator.
@@ -217,7 +215,7 @@ only_rules:
   # Operators should be surrounded by a single whitespace when they are being used.
   - operator_usage_whitespace
   # Operators should be surrounded by a single whitespace when defining them.
-  - operator_whitespace
+  - function_name_whitespace
   # Matching an enum case against an optional enum without ‘?’ is supported on Swift 5.1 and above.
   - optional_enum_case_matching
   # A doc comment should be attached to a declaration.
@@ -259,7 +257,7 @@ only_rules:
   # Objective-C attribute (@objc) is redundant in declaration.
   - redundant_objc_attribute
   # Initializing an optional variable with nil is redundant.
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   # Property setter access level shouldn't be explicit if it's the same as the variable access level.
   - redundant_set_access_control
   # String enum values can be omitted when they are equal to the enumcase name.
@@ -329,8 +327,6 @@ only_rules:
   - unowned_variable_capture
   # Catch statements should not declare error variables without type casting.
   - untyped_error_in_catch
-  # Unused reference in a capture list should be removed.
-  - unused_capture_list
   # Unused parameter in a closure should be replaced with _.
   - unused_closure_parameter
   # Unused control flow label should be removed.

--- a/Balance/Utils/BalanceExtensions.swift
+++ b/Balance/Utils/BalanceExtensions.swift
@@ -134,7 +134,7 @@ extension Notification.Name {
     static let heartAlert = Notification.Name("heartAlert")
 }
 
-// swiftlint:disable operator_whitespace
+// swiftlint:disable function_name_whitespace
 // swiftlint:disable large_tuple
 extension Date {
     static func -(recent: Date, previous: Date) -> (hour: Int?, minute: Int?, second: Int?) {

--- a/Balance/Utils/Constant.swift
+++ b/Balance/Utils/Constant.swift
@@ -43,7 +43,7 @@ enum DistractMeOption: UInt32 {
                 maxValue += 1
             }
             return maxValue
-        }()
+    }()
 
         static func randomSection() -> DistractMeOption {
             // pick and return a new value


### PR DESCRIPTION
## Summary

- Remove `inert_defer` and `unused_capture_list` — no longer valid rule identifiers in SwiftLint 0.63+
- Rename `operator_whitespace` → `function_name_whitespace` in `.swiftlint.yml` and inline disable comment in `BalanceExtensions.swift`
- Rename `redundant_optional_initialization` → `implicit_optional_initialization` in `.swiftlint.yml`
- Fix `closure_end_indentation` violation in `Constant.swift:46`
- Overrides JAVA_HOME to stop using 17 and instead use `$JAVA_HOME_21_arm64`. `firebase emulators:exec` was complaining about using older Java version 

## Test plan

- [x] `swiftlint lint --strict` passes locally with 0 violations on SwiftLint 0.63.2

Closes #209